### PR TITLE
Changed @Input to @InputFiles to consider the content of the js-jars

### DIFF
--- a/jar2npm-plugin/src/main/kotlin/com/crowdproj/plugins/jar2npm/KotlinJar2NpmTask.kt
+++ b/jar2npm-plugin/src/main/kotlin/com/crowdproj/plugins/jar2npm/KotlinJar2NpmTask.kt
@@ -4,6 +4,7 @@ import groovy.json.JsonBuilder
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.slf4j.LoggerFactory
@@ -21,7 +22,7 @@ open class KotlinJar2NpmTask : DefaultTask() {
     /**
      * The configuration used to extract all dependencies
      */
-    @Input
+    @InputFiles
     val conf: Configuration = project
         .configurations
         .getByName("testRuntimeClasspath")


### PR DESCRIPTION
Without the annotation @InputFiles the jar2npm task will be always UP-TO-DATE even if the jar file was changed.