### PR TITLE
Add 'types' to package.json if a .d.ts-file exists

### DIFF
--- a/jar2npm-plugin/src/main/kotlin/com/crowdproj/plugins/jar2npm/KotlinJar2NpmTask.kt
+++ b/jar2npm-plugin/src/main/kotlin/com/crowdproj/plugins/jar2npm/KotlinJar2NpmTask.kt
@@ -91,12 +91,17 @@ open class KotlinJar2NpmTask : DefaultTask() {
                     it.from(project.zipTree(file))
                     it.into(outDir)
                 }
-                val packageJson = mapOf(
+                val packageJson = mutableMapOf(
                     "name" to name,
                     "version" to version,
                     "main" to js,
                     "_source" to "gradle"
                 )
+
+                val ts = "$name.d.ts"
+                if(File(outDir,ts).exists()) {
+                    packageJson["types"] = ts
+                }
 
                 outDir.resolve("package.json").bufferedWriter().use { out ->
                     out.appendln(JsonBuilder(packageJson).toPrettyString())


### PR DESCRIPTION
With the help of some other plugins it is possible to generate a d.ts file for the module.
The jar2npm task should check, if such a file exists and add the corresponding entry in the package.json.